### PR TITLE
Fix: Enable native macOS file picker and add required bundle identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,8 @@ if (WIN32)
     )
 elseif (APPLE)
    set(MACOSX_BUNDLE_ICON_FILE brokkr.icns)
+   set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.brokkr.flash")
+   set(MACOSX_BUNDLE_BUNDLE_NAME "Brokkr")
    set_source_files_properties(assets/brokkr.icns PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
     add_executable(brokkr MACOSX_BUNDLE
         src-gui/main_gui.cpp
@@ -379,7 +381,7 @@ target_compile_definitions(brokkr PRIVATE
 
 qt_generate_deploy_app_script(
     TARGET brokkr
-    FILENAME_VARIABLE deploy_script
+    OUTPUT_SCRIPT deploy_script
     NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/src-gui/brokkr_wrapper.cpp
+++ b/src-gui/brokkr_wrapper.cpp
@@ -609,7 +609,7 @@ BrokkrWrapper::BrokkrWrapper(QWidget* parent) : QWidget(parent) {
   connect(btnPitBrowse, &QPushButton::clicked, this, [this]() {
     if (busy_) return;
     QFileDialog::Options opts;
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX)
     opts |= QFileDialog::DontUseNativeDialog;
 #endif
     const QString file = QFileDialog::getOpenFileName(this, "Select PIT File", lastDir,
@@ -2143,7 +2143,7 @@ void BrokkrWrapper::setupOdinFileInput(QGridLayout* layout, int row, const QStri
   connect(btn, &QPushButton::clicked, this, [this, lineEdit, chk]() {
     if (busy_) return;
     QFileDialog::Options opts;
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX)
     opts |= QFileDialog::DontUseNativeDialog;
 #endif
     QString file = QFileDialog::getOpenFileName(this, "Select Firmware File", lastDir,


### PR DESCRIPTION
## Description
This PR addresses an issue where the native macOS file picker (`NSOpenPanel`) was explicitly disabled via `QFileDialog::DontUseNativeDialog`. It also adds the necessary `MACOSX_BUNDLE_GUI_IDENTIFIER` and `MACOSX_BUNDLE_BUNDLE_NAME` properties to the CMake configuration, which are required by macOS to grant the application permissions to open the native file dialog.

## Changes Made
- Modified `src-gui/brokkr_wrapper.cpp` so that `QFileDialog::DontUseNativeDialog` is only applied on Linux.
- Added macOS bundle identifier properties to the `brokkr` target in `CMakeLists.txt`.